### PR TITLE
Rabbit MQ Support added.

### DIFF
--- a/integration_tester/driver.py
+++ b/integration_tester/driver.py
@@ -24,21 +24,21 @@ class Driver:
     """
     _status = True
 
-    def __init__(self, pull: str, ports: Dict[int, None] = {},
+    def __init__(self, tag: str, ports: Dict[int, None] = {},
                  remove_image: bool = False):
         """ Initialise the driver.
 
         Inintialisation includes running docker.
 
         Args:
-            pull: The docker image to pull from dockerhub.
+            tag: The docker image to pull from dockerhub.
             host: Address to bind.
             ports: Ports to expose from the container.
         """
-        self._pull = pull
+        self._tag = tag 
         self._remove_image = remove_image
 
-        self._container = CLIENT.containers.run(pull, detach=True, ports=ports)
+        self._container = CLIENT.containers.run(self._tag, detach=True, ports=ports)
 
     def __del__(self) -> None:
         """ Ensure proper removal of docker resources.

--- a/integration_tester/rabbitmq_driver.py
+++ b/integration_tester/rabbitmq_driver.py
@@ -1,0 +1,56 @@
+try:
+    import pika
+except ModuleNotFoundError as error:
+    raise Exception("To support MongoDB please install the mongo package"
+                    " optional extra.") from error
+
+from integration_tester import driver
+
+
+class RabbitMQDriver(driver.Driver):
+
+    def __init__(self, tag: str = "latest", host: str = "127.0.0.1",
+                 port: int = 5672, username: str = "guest",
+                 password: str = "guest"):
+        self.host, self.port = host, port
+        self.username, self.password = username, password
+        ports = {5672: (host, port)}
+        super().__init__(f"rabbitmq:{tag}", ports)
+
+    def ready(self):
+        """ Check if RabbitMQ has started.
+
+        This function returns True if the RabbitMQ service within the container
+        is running and ready to accept connections.
+        """
+        credentials = pika.PlainCredentials(self.username, self.password)
+        parameters = pika.ConnectionParameters(
+            self.host,
+            self.port,
+            '/',
+            credentials
+        )
+        try:
+            connection = pika.BlockingConnection(parameters)
+        except pika.exceptions.IncompatibleProtocolError as error:
+            return False
+        connected = connection.is_open
+        connection.close()
+        return connected
+
+    def reset(self, queues):
+        """ Reset RabbitMQ to factory new. """
+        # TODO(Liam) this requires the user to provide each queue. There is no
+        # way to check what queues have been created and the relies on the user
+        # reseting the queue. Check if there is another way to do this.
+        credentials = pika.PlainCredentials(self.username, self.password)
+        parameters = pika.ConnectionParameters(
+            self.host,
+            self.port,
+            '/',
+            credentials
+        )
+        connection = pika.BlockingConnection(parameters)
+        channel = connection.channel()
+        for queue in queues:
+            channel.queue_delete(queue=queue)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     keywords='ci integration testing',
-    package_dir={'': 'integration_tester'},
     python_requires='>=3.7, <4',
     install_requires=[
         'docker',
@@ -40,6 +39,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=[
         'mongo',
+        'pika',
         'pytest',
         'redis',
     ],

--- a/test/test_mongo.py
+++ b/test/test_mongo.py
@@ -16,6 +16,3 @@ def test_mongo():
 
     database.reset()
     assert not list(collection.find({}))
-
-    del(database)
-

--- a/test/test_rabbitmq.py
+++ b/test/test_rabbitmq.py
@@ -1,0 +1,29 @@
+import pika
+import pytest
+
+from integration_tester import rabbitmq_driver
+
+
+def test_rabbitmqdriver():
+    drive = rabbitmq_driver.RabbitMQDriver(tag="3.8-management")
+    drive.wait_until_ready()
+    
+    credentials = pika.PlainCredentials("guest", "guest")
+    parameters= pika.ConnectionParameters("127.0.0.1", "5672", '/', credentials)
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    channel.queue_declare("test")
+
+    channel.basic_publish(exchange="", routing_key="test", body=b'Test message 1.')
+    channel.basic_publish(exchange="", routing_key="test", body=b'Test message 2.')
+
+    def consume_test(method_frame, properties, body):
+        assert body == b'Test message 1.'
+    channel.basic_consume(queue="test", auto_ack=True, on_message_callback=consume_test)
+
+    drive.reset(['test'])
+    
+    with pytest.raises(pika.exceptions.ChannelClosedByBroker):
+        channel.basic_consume(queue="test", auto_ack=True, on_message_callback=consume_test)
+    
+    del(drive)


### PR DESCRIPTION
This Update has a testing issue when using "setup.py test". For this
purpose, please use "python -m pytest test" instead.

The issue prevents the shutting down of the container. This issue is
external to this project and only effects testing.

Added RabbitMQ support and cleanup. This module can be drastically
improved.