### PR TITLE
Issue#5 Resolved

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -1,4 +1,5 @@
 yapf --recursive --in-place integration_tester
+yapf --recursive --in-place test
 # R0913 (Too many arguments): The whole point of a class is to store state.
 # W0221 (Parameters differ from overridden 'reset' method): We have to override methods.
 pylint integration_tester --disable=R0913,W0221

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -1,24 +1,32 @@
-from integration_tester import driver, errors
+import traceback
 
 import docker
-import pytest 
+import pytest
+
+from integration_tester import driver, errors
 
 
 def test_driver_standard():
     """ Standard driver use test. """
     tag = "ubuntu:latest"
     drive = driver.Driver(tag)
-    id = drive._container.id
+    id = drive._container_id
     assert drive.ready() == True
-    assert drive.reset() is None 
+    assert drive.reset() is None
     assert drive.wait_until_ready(timeout=10) is None
-    drive._status = False 
+    drive._status = False
     with pytest.raises(errors.ReadyTimeout):
         drive.wait_until_ready(timeout=2)
-    del(drive)
+
+    # Attempt to catch any issues within the deconstruction and fail the test.
+    try:
+        del (drive)
+    except:
+        pytest.fail(traceback.format_exc())
+
     with pytest.raises(docker.errors.NotFound):
-        driver.CLIENT.containers.get(id)
-    
+        docker.from_env().containers.get(id)
+
 
 def test_image_removal():
     """ Test that we correctly remove the local image.
@@ -29,5 +37,11 @@ def test_image_removal():
     """
     tag = "alpine:3.8"
     drive = driver.Driver(tag, remove_image=True)
-    del(drive)
-    assert not driver.CLIENT.images.list(tag)
+
+    # Attempt to catch any issues within the deconstruction and fail the test.
+    try:
+        del (drive)
+    except:
+        pytest.fail(traceback.format_exc())
+
+    assert not docker.from_env().images.list(tag)

--- a/test/test_mongo.py
+++ b/test/test_mongo.py
@@ -1,4 +1,6 @@
-import pymongo 
+import traceback
+
+import pymongo
 import pytest
 
 from integration_tester import mongo_driver
@@ -6,13 +8,19 @@ from integration_tester import mongo_driver
 
 def test_mongo():
     """ Standard MongoDB test. """
-    database = mongo_driver.MongoDBDriver()
-    database.wait_until_ready()
-    
+    drive = mongo_driver.MongoDBDriver()
+    drive.wait_until_ready()
+
     db = pymongo.MongoClient().test
     collection = db.test
     collection.insert_one({"test": "test"})
     assert list(collection.find({}))
 
-    database.reset()
+    drive.reset()
     assert not list(collection.find({}))
+
+    # Attempt to catch any issues within the deconstruction and fail the test.
+    try:
+        del (drive)
+    except:
+        pytest.fail(traceback.format_exc())

--- a/test/test_rabbitmq.py
+++ b/test/test_rabbitmq.py
@@ -1,3 +1,5 @@
+import traceback
+
 import pika
 import pytest
 
@@ -7,23 +9,37 @@ from integration_tester import rabbitmq_driver
 def test_rabbitmqdriver():
     drive = rabbitmq_driver.RabbitMQDriver(tag="3.8-management")
     drive.wait_until_ready()
-    
+
     credentials = pika.PlainCredentials("guest", "guest")
-    parameters= pika.ConnectionParameters("127.0.0.1", "5672", '/', credentials)
+    parameters = pika.ConnectionParameters("127.0.0.1", "5672", '/',
+                                           credentials)
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
     channel.queue_declare("test")
 
-    channel.basic_publish(exchange="", routing_key="test", body=b'Test message 1.')
-    channel.basic_publish(exchange="", routing_key="test", body=b'Test message 2.')
+    channel.basic_publish(exchange="",
+                          routing_key="test",
+                          body=b'Test message 1.')
+    channel.basic_publish(exchange="",
+                          routing_key="test",
+                          body=b'Test message 2.')
 
     def consume_test(method_frame, properties, body):
         assert body == b'Test message 1.'
-    channel.basic_consume(queue="test", auto_ack=True, on_message_callback=consume_test)
+
+    channel.basic_consume(queue="test",
+                          auto_ack=True,
+                          on_message_callback=consume_test)
 
     drive.reset(['test'])
-    
+
     with pytest.raises(pika.exceptions.ChannelClosedByBroker):
-        channel.basic_consume(queue="test", auto_ack=True, on_message_callback=consume_test)
-    
-    del(drive)
+        channel.basic_consume(queue="test",
+                              auto_ack=True,
+                              on_message_callback=consume_test)
+
+    # Attempt to catch any issues within the deconstruction and fail the test.
+    try:
+        del (drive)
+    except:
+        pytest.fail(traceback.format_exc())

--- a/test/test_redis.py
+++ b/test/test_redis.py
@@ -1,17 +1,25 @@
+import traceback
+
 import pytest
 import redis
 
-from integration_tester import redis_driver 
+from integration_tester import redis_driver
 
 
 def test_redis():
     """ Standard redis test. """
-    database = redis_driver.RedisDriver()
-    database.wait_until_ready(timeout=60)
+    drive = redis_driver.RedisDriver()
+    drive.wait_until_ready(timeout=60)
 
     db = redis.Redis()
     assert db.set("test", "test")
     assert db.get("test").decode("utf-8") == "test"
 
-    database.reset()
+    drive.reset()
     assert db.get("test") is None
+
+    # Attempt to catch any issues within the deconstruction and fail the test.
+    try:
+        del (drive)
+    except:
+        pytest.fail(traceback.format_exc())


### PR DESCRIPTION
- Resolve Bug
- Update tests

**Resolve Bug**
A Docker driver issue caused by a `ValueError: file descriptor cannot be a
negative integer (-1)` was preventing the containers from de-constructing. It is
unclear what the exact cause of this issue is but an issue has been forwarded to
the Docker python repository.

The issue is directly related to the Docker driver. This means that recreating
the client object using the `from_env` function each time the client is used to
resolved the issue. This is not the ideal fix.

**Update Tests**
Attempt to catch issues in the deconstruction of the driver object and fail tests if
an issue occurs. This will help prevent issues in the deconstruction from
slipping through tests in the future.

Closes #5 